### PR TITLE
Catch Net::SSH errors to console warn

### DIFF
--- a/lib/statistrano/deployment/ssh.rb
+++ b/lib/statistrano/deployment/ssh.rb
@@ -37,8 +37,9 @@ module Statistrano
           end
         rescue Net::SSH::AuthenticationFailed
           LOG.error "Authentication failed when connecting to '#{@config.remote}'"
-        rescue Exception
-          LOG.error "Error when attempting to connect to '#{@config.remote}'"
+        rescue Exception => e
+          LOG.error "Error when attempting to connect to '#{@config.remote}'" +
+                    "\n\t  msg  #{e.class}: #{e}"
         end
       end
 


### PR DESCRIPTION
In cases where the remote is inaccessible, the [run_command()](https://github.com/mailchimp/statistrano/blob/master/lib/statistrano/deployment/ssh.rb#L21-L41) method doesn't properly catch errors. Extra points for having the errors dumped as warnings to console.

This is partly due to the [setup()](https://github.com/mailchimp/statistrano/blob/master/lib/statistrano/deployment.rb#L34-41) method being called during configuration, which will try and execute a command on the remote.

Here is a stack trace of an error case: 

```
/Users/foo/.rvm/gems/ruby-1.9.3-p385@global/gems/bundler-1.2.4/lib/bundler.rb:263: warning: Insecure world writable dir /usr/local/bin in PATH, mode 040777
rake aborted!
getaddrinfo: nodename nor servname provided, or not known
/Users/foo/.rvm/gems/ruby-1.9.3-p385/gems/net-ssh-2.6.7/lib/net/ssh/transport/session.rb:67:in `initialize'
/Users/foo/.rvm/gems/ruby-1.9.3-p385/gems/net-ssh-2.6.7/lib/net/ssh/transport/session.rb:67:in `open'
/Users/foo/.rvm/gems/ruby-1.9.3-p385/gems/net-ssh-2.6.7/lib/net/ssh/transport/session.rb:67:in `block in initialize'
/Users/foo/.rvm/gems/ruby-1.9.3-p385/gems/net-ssh-2.6.7/lib/net/ssh/transport/session.rb:67:in `initialize'
/Users/foo/.rvm/gems/ruby-1.9.3-p385/gems/net-ssh-2.6.7/lib/net/ssh.rb:192:in `new'
/Users/foo/.rvm/gems/ruby-1.9.3-p385/gems/net-ssh-2.6.7/lib/net/ssh.rb:192:in `start'
/Users/foo/.rvm/gems/ruby-1.9.3-p385/bundler/gems/statistrano-7345349a56e0/lib/statistrano/deployment/ssh.rb:26:in `run_command'
/Users/foo/.rvm/gems/ruby-1.9.3-p385/bundler/gems/statistrano-7345349a56e0/lib/statistrano/deployment.rb:74:in `setup'
/Users/foo/.rvm/gems/ruby-1.9.3-p385/bundler/gems/statistrano-7345349a56e0/lib/statistrano/deployment.rb:48:in `after_configuration'
/Users/foo/.rvm/gems/ruby-1.9.3-p385/bundler/gems/statistrano-7345349a56e0/lib/statistrano/deployment/releases.rb:37:in `after_configuration'
/Users/foo/.rvm/gems/ruby-1.9.3-p385/bundler/gems/statistrano-7345349a56e0/lib/statistrano.rb:45:in `define_deployment'
/Users/foo/Sites/test-project/Rakefile:3:in `<top (required)>'
```
