### PR TITLE
Should Log.error abort?

### DIFF
--- a/lib/statistrano/log.rb
+++ b/lib/statistrano/log.rb
@@ -28,6 +28,7 @@ module Statistrano
     # @param [String] text
     def error text, status="error", color=:red
       shell_say text, status, color
+      abort()
     end
 
     private


### PR DESCRIPTION
Just realizing that whenever we hit Log.error we should probably abort. If the deployment hits a snag, it logs and continues on it's merry way potentially FUBARing a site in the process. If an error isn't abort worthy it should probably just be warned anyway -- that or have a boolean for abort/don't abort?

@jordanandree thoughts?
